### PR TITLE
Fix invalid GitHub Actions publish workflow (#3)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,51 @@
+name: Publish Python 🐍 distribution 📦 to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
   publish-to-pypi:
-    needs: build
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    needs:
+    - build
     runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/p/py_document_chunker
     permissions:
       id-token: write
-      contents: read
+
     steps:
-    - uses: actions/download-artifact@v4
-      with: {name: python-package-distributions, path: dist/}
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The .github/workflows/publish.yml file was invalid, causing the GitHub Actions workflow to fail. This was due to a missing `jobs` property and an unexpected value at the start of the file.

This change replaces the invalid workflow with a complete and correct one based on the official Python packaging guide. The new workflow will:
- Trigger on new releases.
- Build the sdist and wheel distribution packages.
- Publish the packages to PyPI using trusted publishing.