### PR TITLE
Fix CI test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           python-version: "3.11"
       - run: pip install -e .[dev] coverage[toml] pytest pytest-cov
+      - run: python -c "import nltk; nltk.download('punkt'); nltk.download('punkt_tab')"
       - run: pytest --cov=py_document_chunker --cov-report=xml
       - uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
This commit fixes the CI test failures by downloading the `nltk` `punkt` and `punkt_tab` tokenizer models before running the tests. This ensures that the `nltk` library has the necessary data to run the tests.