### PR TITLE
fix(deps): Pin spacy and numpy to resolve build and test failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,10 @@ nlp = [
     "nltk>3.8.1",
 ]
 spacy = [
-    "spacy>=3.7.0",
+    "spacy==3.7.2",
 ]
 semantic = [
-    "numpy>=2.0.0",
+    "numpy<2.0.0",
 ]
 code = [
     "tree-sitter>=0.21.0",


### PR DESCRIPTION
Pinned spacy to 3.7.2 to resolve a build failure of the blis dependency on Windows. Pinned numpy to <2.0.0 to resolve a binary incompatibility with thinc.