### PR TITLE
Fix CI warnings and cache issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2022]
         python-version: ['3.11', '3.12']
 
     steps:
@@ -42,21 +42,16 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install Poetry
-        run: |
-          pip install pipx
-          pipx install poetry
-
-      - name: Configure Poetry and cache dependencies
         id: cached-poetry-dependencies
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'poetry'
+
+      - name: Install Poetry
+        run: |
+          pip install pipx
+          pipx install poetry
 
       - name: Install dependencies
         run: poetry install --with dev --all-extras


### PR DESCRIPTION
This commit addresses two issues in the CI workflow:

1.  Updates the Windows runner from `windows-latest` to `windows-2022` to prevent warnings about the upcoming migration to Windows Server 2025.
2.  Consolidates the Python setup and Poetry dependency caching into a single step to resolve intermittent cache failures.